### PR TITLE
Spelling: Debian GNU/Linux, GPG, PowerPC, AMD64, HTTPS, Java

### DIFF
--- a/i2p2www/pages/downloads/debian.html
+++ b/i2p2www/pages/downloads/debian.html
@@ -10,7 +10,7 @@ have been tested and <em>should </em>work on x86/x86_64 platforms running:
 <ul>
   <li>{% trans %}<a href="#ubuntu">Ubuntu</a> (Precise <em>12.04</em> and newer){% endtrans %}</li>
   <li><a href="#ubuntu">Mint</a></li>
-  <li>{% trans %}<a href="#debian">Debian Linux</a> (Wheezy and newer){% endtrans %}</li>
+  <li>{% trans %}<a href="#debian">Debian GNU/Linux</a> (Wheezy and newer){% endtrans %}</li>
   <li><a href="#debian">Knoppix</a></li>
 </ul>
 
@@ -32,7 +32,7 @@ with these packages on <a href="{{ trac }}">Trac</a> at
     <code>&nbsp;&nbsp;&nbsp; sudo apt-add-repository ppa:i2p-maintainers/i2p</code><br />
 {% trans -%}
 This command will add the PPA to /etc/apt/sources.list.d and fetch the
-gpg key that the repository has been signed with. The GPG key ensures
+GPG key the repository has been signed with. The GPG key ensures
 that the packages have not been tampered with since being built.
 {%- endtrans %}
   </li>
@@ -80,7 +80,7 @@ part of <a href="#Post-install_work">starting I2P</a> and configuring it for you
 
 <h2 id="debian">{{ _('Instructions for Debian') }}</h2>
 
-<em>Currently supported architectures include amd64, i386, armel, armhf (for Raspbian), and powerpc.</em>
+<em>Currently supported architectures include AMD64, i386, armel, armhf (for Raspbian), and PowerPC.</em>
 
 <p>{% trans -%}
 Note: The steps below should be performed with root access (i.e., switching
@@ -154,7 +154,7 @@ After the installation process completes you can move on to the next part of <a 
 
 <p>
 {% trans -%}
-Note: If the https address does not work, either:
+Note: If the HTTPS address does not work, either:
 {%- endtrans %}
 <ol><li><code>sudo apt-get install apt-transport-https</code></li>
 <li>
@@ -180,7 +180,7 @@ sudo or run it as root!)
   </li>
   <li>
     {% trans -%}
-    &quot;on demand&quot; without the <a href="http://wrapper.tanukisoftware.com/">java service wrapper</a>
+    &quot;on demand&quot; without the <a href="http://wrapper.tanukisoftware.com/">Java service wrapper</a>
 (needed on non-Linux/non-x86 systems) by running "<code>i2prouter-nowrapper</code>".
 (Note: Do <strong><u>not</u></strong>
 use sudo or run it as root!)


### PR DESCRIPTION
Going with the architecture names, and not the ports for them.