### PR TITLE
Wrong Language Name Fix

### DIFF
--- a/i2p2www/__init__.py
+++ b/i2p2www/__init__.py
@@ -77,7 +77,7 @@ SUPPORTED_LANG_NAMES = {
     'he': u'Hebrew עברית',
     'it': u'Italiano',
     'ja': u'Japanese 日本語',
-    'ko': u'Korean 한국말',
+    'ko': u'Korean 한국어',
     'mg': u'Fiteny Malagasy',
     'nl': u'Nederlands',
     'fa': u'Persian فارسی',


### PR DESCRIPTION
한국 means 'Korean', 말 means 'Speaking', 어 means 'Language'.
So 한국어 means 'Korean Language=Korean'.
Example: [Microsoft](https://www.microsoft.com/en-us/locale.aspx), [Google](https://www.google.com/preferences#languages)