### PR TITLE
SAM V3: make example consistent with previous text

### DIFF
--- a/i2p2www/pages/site/docs/api/samv3.html
+++ b/i2p2www/pages/site/docs/api/samv3.html
@@ -677,7 +677,7 @@ For most low- to medium-bandwidth and low- to medium-connection counts,
 2 or 3 is sufficient.
 Please specify the tunnel quantities in the SESSION CREATE message
 to get consistent performance with the Java I2P and i2pd routers,
-using the options e.g. inbound.length=3 outbound.length=3.
+using the options e.g. inbound.quantity=3 outbound.quantity=3.
 These and other options <a href="#options">are documented in the links below</a>.
 </p><p>
 


### PR DESCRIPTION
This paragraph explains how to use `quantity` parameter:
https://github.com/i2p/i2p.www/blob/84d35a67c71184eb8dbe19272208541fd6fdf750/i2p2www/pages/site/docs/api/samv3.html#L674-L679
However example use `length` parameter instead:
https://github.com/i2p/i2p.www/blob/84d35a67c71184eb8dbe19272208541fd6fdf750/i2p2www/pages/site/docs/api/samv3.html#L680
I think it is better to make example match previous text.